### PR TITLE
Reshaping rank fix

### DIFF
--- a/Sources/MPSX/ONNX/Nodes/Convolution.swift
+++ b/Sources/MPSX/ONNX/Nodes/Convolution.swift
@@ -149,7 +149,7 @@ extension MPSGraph {
             )
         }
 
-        let output = bias.flatMap { convolution + reshapeHW($0, rank: shape.count - 1) } ?? convolution
+        let output = bias.flatMap { convolution + appendDimmsIfNeeded(to: $0, count: shape.count - 2) } ?? convolution
 
         return output
     }
@@ -234,7 +234,7 @@ extension MPSGraph {
             name: nil
         )
 
-        let output = bias.flatMap { convolution + reshapeHW($0, rank: 3) } ?? convolution
+        let output = bias.flatMap { convolution + appendDimmsIfNeeded(to: $0, count: 2) } ?? convolution
 
         return output
     }

--- a/Sources/MPSX/ONNX/Nodes/Convolution.swift
+++ b/Sources/MPSX/ONNX/Nodes/Convolution.swift
@@ -88,7 +88,8 @@ extension MPSGraph {
     ) throws -> MPSGraphTensor {
         let groups = groups ?? 1
 
-        guard let strides = (strides ?? [1, 1]).pair,
+        guard let shape = input.shape,
+              let strides = (strides ?? [1, 1]).pair,
               let dilations = (dilations ?? [1, 1]).pair,
               let pads = (pads ?? [0, 0, 0, 0]).quad
         else {
@@ -148,7 +149,7 @@ extension MPSGraph {
             )
         }
 
-        let output = bias.flatMap { convolution + reshapeHW($0) } ?? convolution
+        let output = bias.flatMap { convolution + reshapeHW($0, rank: shape.count - 1) } ?? convolution
 
         return output
     }
@@ -233,7 +234,7 @@ extension MPSGraph {
             name: nil
         )
 
-        let output = bias.flatMap { convolution + reshapeHW($0) } ?? convolution
+        let output = bias.flatMap { convolution + reshapeHW($0, rank: 3) } ?? convolution
 
         return output
     }

--- a/Sources/MPSX/ONNX/Nodes/Internal/ReshapeHW.swift
+++ b/Sources/MPSX/ONNX/Nodes/Internal/ReshapeHW.swift
@@ -1,10 +1,9 @@
 import MetalPerformanceShadersGraph
 
 extension MPSGraph {
-    func reshapeHW(_ tensor: MPSGraphTensor, rank: Int) -> MPSGraphTensor {
+    func appendDimmsIfNeeded(to tensor: MPSGraphTensor, count: Int) -> MPSGraphTensor {
         if let shape = tensor.shape, shape.count == 1 {
-            
-            return tensor.reshape([shape[0].intValue] + Array(repeating: 1, count: rank - 1))
+            return tensor.reshape(shape.map(\.intValue) + Array(repeating: 1, count: count))
         }
         return tensor
     }

--- a/Sources/MPSX/ONNX/Nodes/Internal/ReshapeHW.swift
+++ b/Sources/MPSX/ONNX/Nodes/Internal/ReshapeHW.swift
@@ -1,9 +1,10 @@
 import MetalPerformanceShadersGraph
 
 extension MPSGraph {
-    func reshapeHW(_ tensor: MPSGraphTensor) -> MPSGraphTensor {
+    func reshapeHW(_ tensor: MPSGraphTensor, rank: Int) -> MPSGraphTensor {
         if let shape = tensor.shape, shape.count == 1 {
-            return tensor.reshape([shape[0].intValue, 1, 1])
+            
+            return tensor.reshape([shape[0].intValue] + Array(repeating: 1, count: rank - 1))
         }
         return tensor
     }

--- a/Sources/MPSX/ONNX/Nodes/Normalization.swift
+++ b/Sources/MPSX/ONNX/Nodes/Normalization.swift
@@ -14,13 +14,13 @@ extension MPSGraph {
               let variance = tensors(node.input(4))
         else { throw OnnxError.invalidInput(node.name) }
 
-        let rank = shape.count - 1
+        let extraDimms = shape.count - 2
         let output = normalize(
             input,
-            mean: reshapeHW(mean, rank: rank),
-            variance: reshapeHW(variance, rank:rank),
-            gamma: reshapeHW(gamma, rank: rank),
-            beta: reshapeHW(beta, rank: rank),
+            mean: appendDimmsIfNeeded(to: mean, count: extraDimms),
+            variance: appendDimmsIfNeeded(to: variance, count: extraDimms),
+            gamma: appendDimmsIfNeeded(to: gamma, count: extraDimms),
+            beta: appendDimmsIfNeeded(to: beta, count: extraDimms),
             epsilon: node.attr(f: "epsilon") ?? 1e-05,
             name: nil
         )
@@ -44,13 +44,13 @@ extension MPSGraph {
 
         let (mean, variance) = input.meanAndVariance(axes: Array(2 ..< shape.count))
 
-        let rank = shape.count - 1
+        let extraDimms = shape.count - 2
         let output = normalize(
             input,
             mean: mean,
             variance: variance,
-            gamma: reshapeHW(gamma, rank: rank),
-            beta: reshapeHW(beta, rank: rank),
+            gamma: appendDimmsIfNeeded(to: gamma, count: extraDimms),
+            beta: appendDimmsIfNeeded(to: beta, count: extraDimms),
             epsilon: node.attr(f: "epsilon") ?? 1e-05,
             name: nil
         )

--- a/Sources/MPSX/ONNX/Nodes/Normalization.swift
+++ b/Sources/MPSX/ONNX/Nodes/Normalization.swift
@@ -7,18 +7,20 @@ extension MPSGraph {
         _ tensors: [String: MPSGraphTensor]
     ) throws -> MPSGraphTensor {
         guard let input = tensors(node.input(0)),
+              let shape = input.shape,
               let gamma = tensors(node.input(1)),
               let beta = tensors(node.input(2)),
               let mean = tensors(node.input(3)),
               let variance = tensors(node.input(4))
         else { throw OnnxError.invalidInput(node.name) }
 
+        let rank = shape.count - 1
         let output = normalize(
             input,
-            mean: reshapeHW(mean),
-            variance: reshapeHW(variance),
-            gamma: reshapeHW(gamma),
-            beta: reshapeHW(beta),
+            mean: reshapeHW(mean, rank: rank),
+            variance: reshapeHW(variance, rank:rank),
+            gamma: reshapeHW(gamma, rank: rank),
+            beta: reshapeHW(beta, rank: rank),
             epsilon: node.attr(f: "epsilon") ?? 1e-05,
             name: nil
         )
@@ -42,12 +44,13 @@ extension MPSGraph {
 
         let (mean, variance) = input.meanAndVariance(axes: Array(2 ..< shape.count))
 
+        let rank = shape.count - 1
         let output = normalize(
             input,
             mean: mean,
             variance: variance,
-            gamma: reshapeHW(gamma),
-            beta: reshapeHW(beta),
+            gamma: reshapeHW(gamma, rank: rank),
+            beta: reshapeHW(beta, rank: rank),
             epsilon: node.attr(f: "epsilon") ?? 1e-05,
             name: nil
         )


### PR DESCRIPTION
Current reshapeHW function works only for 4 rank tensors, fix it to work with any rank variant