### PR TITLE
Fix reshape allowzero default logic

### DIFF
--- a/Sources/MPSX/ONNX/Nodes/Reshape.swift
+++ b/Sources/MPSX/ONNX/Nodes/Reshape.swift
@@ -7,11 +7,19 @@ extension MPSGraph {
         _ tensors: [String: MPSGraphTensor],
         _ constants: [String: Onnx_TensorProto]
     ) throws -> MPSGraphTensor {
-        guard let input = tensors(node.input(0)) else {
+        guard let input = tensors(node.input(0)),
+              let inputShape = input.shape
+        else {
             throw OnnxError.invalidInput(node.name)
         }
-
-        if let shape = constants(node.input(1))?.ints {
+        
+        if var shape = constants(node.input(1))?.ints {
+            // allowzero = false
+            for (index, dimm) in shape.enumerated() {
+                if dimm == 0 {
+                    shape[index] = inputShape[index].intValue
+                }
+            }
             return input.reshape(shape)
         }
 


### PR DESCRIPTION
Current reshaping function doesn't work well with zero axes parameters, handling here allowzero = false case as it's a default one